### PR TITLE
Change to multitask.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,66 @@ grunt.loadNpmTasks('grunt-lessless');
 [grunt]: https://github.com/cowboy/grunt
 [getting_started]: https://github.com/cowboy/grunt/blob/master/docs/getting_started.md
 
-## Documentation
-Add this to your Gruntfile.js:
+## Lessless task
+_Run this task with the `grunt lessless` command._
+
+_This task is a [multi task][] so any targets, files and options should be specified according to the [multi task][] documentation._
+[multi task]: https://github.com/gruntjs/grunt/wiki/Configuring-tasks
+
+### Options
+
+#### buildDir
+Type: `String`
+
+Directory to scan for less files.
+
+#### styleDirs
+Type: `String`
+Default: null
+
+Directories to look in for imports. Usually not needed since any folder containing a .less file gets added to this automatically.
+
+#### stripExtensions
+Type: `Array`
+Default: ['html']
+
+File extensions that have links to .less files.
+So a Java project would typically set `stripExtensions` to `['jsp', 'html']` and a .NET project would set it to `['cshtml', 'html']`. 
+
+### Usage Examples
 
 ```js
 lessless: {
-  buildDir: 'path/to/frontend-build'
+  compile: {
+    buildDir: 'path/to/frontend-build'
+  }
 }
 ```
+
 If you're using RequireJS then `buildDir` should match `dir` from your requirejs settings. With grunt you can even point to the same variable: 
 
 ```js
 lessless: {
-  buildDir: '<%= requirejs.compile.options.dir %>'
+  compile: {
+    buildDir: '<%= requirejs.compile.options.dir %>'
+  }
 }
 ```
 
 There are also two optional settings:
 ```js
 lessless: {
-  buildDir: 'path/to/frontend-build'
-  styleDirs: ['path/to/my/extra/styles'], //directories to look in for imports. usually don't need since any folder containing a .less file gets added to this automatically
-  stripExtensions: ['jsp', 'html'] //file extensions that have links to .less files. Defaults to just .html files.
+  compile: {
+    buildDir: 'path/to/frontend-build',
+    styleDirs: ['path/to/my/extra/styles'],
+    stripExtensions: ['jsp', 'html']
+  }
 }
 ```
-So a Java project would typically set `stripExtensions` to `['jsp', 'html']` and a .NET project would set it to `['cshtml', 'html']`. 
 
 ## Release History
-0.1.0 initial release. 
+- 0.1.1 Change to multitask
+- 0.1.0 initial release. 
 
 ## License
 Copyright (c) 2012 Dave Geddes  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lessless",
   "description": "compile LESS into CSS, change links to point to the CSS files, remove less.js from page",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/geddesign/grunt-lessless",
   "author": {
     "name": "Dave Geddes",

--- a/tasks/lessless.js
+++ b/tasks/lessless.js
@@ -11,7 +11,7 @@ var lessless = require('lessless');
 
 module.exports = function(grunt) {
 
-  grunt.registerTask('lessless', 'compile LESS into CSS via lessless', function() {
+  grunt.registerMultiTask('lessless', 'compile LESS into CSS via lessless', function() {
     //log with grunt
     lessless.setConsole({
       log: function(msg){
@@ -23,9 +23,9 @@ module.exports = function(grunt) {
     var done = this.async();
     // lessless.optimizeProject(grunt.config.get("requirejs.compile.options.dir"));
     lessless.optimizeProject(
-      grunt.config.get("lessless.buildDir"),
-      grunt.config.get('lessless.styledirs'),
-      grunt.config.get('lessless.stripExtensions')
+      this.data.buildDir,
+      this.data.styleDirs,
+      this.data.stripExtensions
       );
     done();
   });


### PR DESCRIPTION
I converted this task to a mulitask to allow for multiple targets with different configurations.
The use case I had was that I needed different targets so that I could specify two different `buildDir` parameters.

I updated the README to reflect the change, and to be formatted more like the other grunt-contrib plugin's READMEs.
